### PR TITLE
update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ tkinterdnd2-universal==1.7.3; sys_platform == 'darwin' and platform_machine == '
 pillow==10.0.0
 onnxruntime==1.15.1; python_version != '3.9' and sys_platform == 'darwin' and platform_machine != 'arm64'
 onnxruntime-coreml==1.13.1; python_version == '3.9' and sys_platform == 'darwin' and platform_machine != 'arm64'
-onnxruntime-silicon==1.13.1; sys_platform == 'darwin' and platform_machine == 'arm64'
+onnxruntime-silicon; sys_platform == 'darwin' and platform_machine == 'arm64'
 onnxruntime-gpu==1.15.1; sys_platform != 'darwin'
 tensorflow==2.13.0
 opennsfw2==0.10.2


### PR DESCRIPTION
as 1.13.1 version of onnxruntime-silicon is unavailable, let install the latest version
Tested on Macbook pro 2021 with M1 CPU